### PR TITLE
fix: use timingSafeEqual for secure token comparison (#493)

### DIFF
--- a/src/dal/auth/refresh/verifyRefreshToken.test.ts
+++ b/src/dal/auth/refresh/verifyRefreshToken.test.ts
@@ -133,6 +133,27 @@ describe('verifyRefreshToken - Unit Tests', () => {
                 reasons: [],
             });
         });
+
+        it('should throw AuthenticationException without crashing when hashes have different lengths', async () => {
+            const dbToken = createMockDBToken({ token: 'short' });
+            mockSha256Hex.mockReturnValue('a-much-longer-hash-value');
+
+            await expect(
+                verifyRefreshToken({
+                    dbToken,
+                    agent: mockAgent,
+                    ipAddress: authMockData.ipAddress,
+                    sendToken: authMockData.refreshToken,
+                    cookieList: mockCookies,
+                    account: mockAccount,
+                    logData: mockLogData,
+                })
+            ).rejects.toMatchObject({
+                message: 'Refresh token hash does not match',
+                exceptionType: 'AuthenticationFailed',
+                debugLevel: LogDebugLevel.WARNING,
+            });
+        });
     });
 
     describe('Token Status Validation', () => {

--- a/src/dal/auth/refresh/verifyRefreshToken.ts
+++ b/src/dal/auth/refresh/verifyRefreshToken.ts
@@ -1,4 +1,5 @@
 import { AuthenticationException, AuthenticationExceptionData } from "@/errors/Authentication";
+import crypto from "crypto";
 import { isValid } from "date-fns";
 import dayjs from "dayjs";
 import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
@@ -21,7 +22,12 @@ type verificationsProp = {
 export const verifyRefreshToken = async (props: verificationsProp): Promise<FingerprintValidationResult> => {
     const { agent, ipAddress, sendToken, dbToken, account, logData } = props;
     const sendTokenHash = sha256Hex(sendToken);
-    if (dbToken.token !== sendTokenHash) {
+    const dbHashBuffer = Buffer.from(dbToken.token, 'utf8');
+    const sendHashBuffer = Buffer.from(sendTokenHash, 'utf8');
+    const hashesMatch =
+        dbHashBuffer.length === sendHashBuffer.length &&
+        crypto.timingSafeEqual(dbHashBuffer, sendHashBuffer);
+    if (!hashesMatch) {
         throw new AuthenticationException("Refresh token hash does not match", "AuthenticationFailed", LogDebugLevel.WARNING, logData);
     }
     if (dbToken.status === 'revoked') {


### PR DESCRIPTION
This pull request addresses ticket #493 by replacing the insecure direct string comparison with `crypto.timingSafeEqual` for refresh token verification. This ensures protection against timing attacks.

### Changes:
- Updated `verifyRefreshToken.ts` to use `crypto.timingSafeEqual`.
- Added a new test case in `verifyRefreshToken.test.ts` to validate behavior for mismatched hash lengths.

### Acceptance Criteria:
- [x] All hash comparisons use `crypto.timingSafeEqual`.
- [x] Both buffers are of equal length before comparison.
- [x] Existing and new unit tests pass.

### Testing:
- All tests pass successfully.

### Notes:
- No database or UI changes were required.